### PR TITLE
Add events handler to track peer events from explorer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dcl/catalyst-peer",
-  "version": "1.0.0-experimental.1",
+  "version": "1.0.0-experimental.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,5 +46,7 @@
     "printWidth": 120,
     "trailingComma": "none"
   },
-  "files": ["dist"]
+  "files": [
+    "dist"
+  ]
 }

--- a/src/Peer.ts
+++ b/src/Peer.ts
@@ -14,12 +14,14 @@ import { MessageData, Packet, PayloadEncoding, PingData, PongData, SuspendRelayD
 import { GlobalStats } from './stats'
 import { TimeKeeper } from './TimeKeeper'
 import {
+  AuthHandler,
   ConnectedPeerData,
   KnownPeerData,
   LogLevel,
   MinPeerData,
   PacketCallback,
   PeerConfig,
+  PeerEventsHandler,
   PeerRelayData,
   PingResult
 } from './types'
@@ -46,6 +48,11 @@ function toParcel(position: any): [number, number] | undefined {
 }
 
 type NetworkOperation = () => Promise<KnownPeerData[]>
+
+type InternalPeerConfig = PeerConfig & {
+  eventsHandler: PeerEventsHandler
+  authHandler: AuthHandler
+}
 
 export class Peer {
   private wrtcHandler: PeerWebRTCHandler
@@ -80,15 +87,20 @@ export class Peer {
 
   private retryingConnection: boolean = false
 
+  private config: InternalPeerConfig
+
   constructor(
     lighthouseUrl: string,
     _peerId?: string,
     public callback: PacketCallback = () => {},
-    private config: PeerConfig = {
-      authHandler: (msg) => Promise.resolve(msg),
-      statusHandler: () => {}
-    }
+    _config: PeerConfig = {}
   ) {
+    this.config = {
+      authHandler: (msg) => Promise.resolve(msg),
+      eventsHandler: {},
+      ..._config
+    }
+
     if (this.config.logLevel) {
       this.logLevel = this.config.logLevel
     }
@@ -145,7 +157,7 @@ export class Peer {
 
     this.wrtcHandler.on(PeerWebRTCEvent.ServerConnectionError, async (err) => {
       if (err.type === PeerErrorType.UnavailableID) {
-        this.config.statusHandler!('id-taken')
+        this.config.eventsHandler.statusHandler?.('id-taken')
       } else {
         if (!this.retryingConnection) await this.retryConnection()
       }
@@ -350,7 +362,7 @@ export class Peer {
         this.log(LogLevel.WARN, `Error while reconnecting (attempt ${i}) `, e)
         if (i >= reconnectionAttempts!) {
           this.log(LogLevel.ERROR, `Could not reconnect after ${reconnectionAttempts} failed attempts `, e)
-          this.config.statusHandler!('reconnection-error')
+          this.config.eventsHandler.statusHandler?.('reconnection-error')
           break
         }
       }
@@ -368,11 +380,11 @@ export class Peer {
   }
 
   set onIslandChange(onChange: ((islandId: string) => any) | undefined) {
-    this.config.onIslandChange = onChange
+    this.config.eventsHandler.onIslandChange = onChange
   }
 
   get onIslandChange() {
-    return this.config.onIslandChange
+    return this.config.eventsHandler.onIslandChange
   }
 
   setIsland(islandId: string, peers: MinPeerData[]) {
@@ -383,7 +395,7 @@ export class Peer {
     this.disconnectFromUnknownPeers()
     this.triggerUpdateNetwork(`changed to island ${islandId}`)
 
-    this.config.onIslandChange?.(islandId)
+    this.config.eventsHandler.onIslandChange?.(islandId)
   }
 
   private cleanStateAndConnections() {
@@ -1132,6 +1144,7 @@ export class Peer {
           if (this.isConnectedTo(peer.id)) this.disconnectFrom(peer.id)
           this.removeKnownPeer(peer.id)
           this.triggerUpdateNetwork(`peer ${peer.id} joined island`)
+          this.config.eventsHandler.onPeerLeftIsland?.(peer.id)
         }
         break
       }
@@ -1140,6 +1153,7 @@ export class Peer {
         if (islandId === this.currentIslandId) {
           this.addKnownPeerIfNotExists(peer)
           this.triggerUpdateNetwork(`peer ${peer.id} joined island`)
+          this.config.eventsHandler.onPeerJoinedIsland?.(peer.id)
         }
         break
       }

--- a/src/Peer.ts
+++ b/src/Peer.ts
@@ -379,7 +379,7 @@ export class Peer {
     }
   }
 
-  set onIslandChange(onChange: ((islandId: string) => any) | undefined) {
+  set onIslandChange(onChange: ((islandId: string, peers: MinPeerData[]) => any) | undefined) {
     this.config.eventsHandler.onIslandChange = onChange
   }
 
@@ -395,7 +395,7 @@ export class Peer {
     this.disconnectFromUnknownPeers()
     this.triggerUpdateNetwork(`changed to island ${islandId}`)
 
-    this.config.eventsHandler.onIslandChange?.(islandId)
+    this.config.eventsHandler.onIslandChange?.(islandId, peers)
   }
 
   private cleanStateAndConnections() {

--- a/src/PeerWebRTCHandler.ts
+++ b/src/PeerWebRTCHandler.ts
@@ -4,7 +4,11 @@ import { future } from 'fp-future'
 import SimplePeer, { SignalData } from 'simple-peer'
 import { PeerSignals, PEER_CONSTANTS } from './constants'
 import { PeerEventType, ServerMessageType } from './peerjs-server-connector/enums'
-import { HandshakeData, PeerJSServerConnection, ValidationMessagePayload } from './peerjs-server-connector/peerjsserverconnection'
+import {
+  HandshakeData,
+  PeerJSServerConnection,
+  ValidationMessagePayload
+} from './peerjs-server-connector/peerjsserverconnection'
 import { ServerMessage } from './peerjs-server-connector/servermessage'
 import { SocketBuilder } from './peerjs-server-connector/socket'
 import { connectionIdFor, util } from './peerjs-server-connector/util'

--- a/src/PeerWebRTCHandler.ts
+++ b/src/PeerWebRTCHandler.ts
@@ -4,7 +4,7 @@ import { future } from 'fp-future'
 import SimplePeer, { SignalData } from 'simple-peer'
 import { PeerSignals, PEER_CONSTANTS } from './constants'
 import { PeerEventType, ServerMessageType } from './peerjs-server-connector/enums'
-import { HandshakeData, PeerJSServerConnection } from './peerjs-server-connector/peerjsserverconnection'
+import { HandshakeData, PeerJSServerConnection, ValidationMessagePayload } from './peerjs-server-connector/peerjsserverconnection'
 import { ServerMessage } from './peerjs-server-connector/servermessage'
 import { SocketBuilder } from './peerjs-server-connector/socket'
 import { connectionIdFor, util } from './peerjs-server-connector/util'
@@ -33,7 +33,7 @@ type OptionalConfig = {
 type Config = {
   packetHandler: (data: Uint8Array, peerId: string) => void
   peerId?: string
-  authHandler: (msg: string) => Promise<string>
+  authHandler: (msg: string) => Promise<ValidationMessagePayload>
   socketBuilder?: SocketBuilder
   wrtc?: WebRTCProvider
 }

--- a/src/PeerWebRTCHandler.ts
+++ b/src/PeerWebRTCHandler.ts
@@ -33,7 +33,7 @@ type OptionalConfig = {
 type Config = {
   packetHandler: (data: Uint8Array, peerId: string) => void
   peerId?: string
-  authHandler?: (msg: string) => Promise<string>
+  authHandler: (msg: string) => Promise<string>
   socketBuilder?: SocketBuilder
   wrtc?: WebRTCProvider
 }

--- a/src/peerjs-server-connector/peerjsserverconnection.ts
+++ b/src/peerjs-server-connector/peerjsserverconnection.ts
@@ -12,6 +12,8 @@ export type MessageHandler = {
   handleMessage(messsage: ServerMessage): void
 }
 
+export type ValidationMessagePayload = any
+
 class PeerOptions {
   debug?: LogLevel // 1: Errors, 2: Warnings, 3: All logs
   host?: string
@@ -24,7 +26,7 @@ class PeerOptions {
   socketBuilder?: SocketBuilder
   heartbeatExtras?: () => object
   logFunction?: (logLevel: LogLevel, ...rest: any[]) => void
-  authHandler?: (msg: string) => Promise<string>
+  authHandler?: (msg: string) => Promise<ValidationMessagePayload>
 }
 
 export type HandshakeData = {
@@ -37,7 +39,7 @@ export function createOfferMessage(myId: string, peerData: ConnectedPeerData, ha
   return createMessage(myId, peerData.id, ServerMessageType.Offer, handshakeData)
 }
 
-export function createValidationMessage(myId: string, payload: string) {
+export function createValidationMessage(myId: string, payload: ValidationMessagePayload) {
   return {
     type: ServerMessageType.Validation,
     src: myId,
@@ -368,7 +370,7 @@ export class PeerJSServerConnection extends EventEmitter {
     this.socket.send(createAnswerMessage(this.id!, peerData, handshakeData))
   }
 
-  sendValidation(payload: string) {
+  sendValidation(payload: ValidationMessagePayload) {
     this.socket.send(createValidationMessage(this.id!, payload))
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,8 @@ export type ValidationResult = {
   message?: string
 }
 
+export type AuthHandler = (msg: string) => Promise<string>
+
 export type PeerConfig = {
   connectionConfig?: any
   wrtc?: any
@@ -63,9 +65,8 @@ export type PeerConfig = {
   logLevel?: LogLevelString
   reconnectionAttempts?: number
   backoffMs?: number
-  authHandler?: (msg: string) => Promise<string>
+  authHandler?: AuthHandler
   positionConfig?: PositionConfig
-  statusHandler?: (status: PeerStatus) => void
   statsUpdateInterval?: number
   /**
    * If not set, the peer won't execute pings regularly.
@@ -81,7 +82,14 @@ export type PeerConfig = {
   relaySuspensionConfig?: RelaySuspensionConfig
   heartbeatInterval?: number
 
+  eventsHandler?: PeerEventsHandler
+}
+
+export type PeerEventsHandler = {
+  statusHandler?: (status: PeerStatus) => void
   onIslandChange?: (islandId: string) => any
+  onPeerLeftIsland?: (peerId: string) => any
+  onPeerJoinedIsland?: (peerId: string) => any
 }
 
 export type RelaySuspensionConfig = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,7 +88,7 @@ export type PeerConfig = {
 
 export type PeerEventsHandler = {
   statusHandler?: (status: PeerStatus) => void
-  onIslandChange?: (islandId: string | undefined) => any
+  onIslandChange?: (islandId: string | undefined, peers: MinPeerData[]) => any
   onPeerLeftIsland?: (peerId: string) => any
   onPeerJoinedIsland?: (peerId: string) => any
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import SimplePeer from 'simple-peer'
 import { Position3D } from './utils/Positions'
 import { SocketBuilder } from './peerjs-server-connector/socket'
 import { Packet } from './proto/peer_protobuf'
+import { ValidationMessagePayload } from 'peerjs-server-connector/peerjsserverconnection'
 
 type PacketSubtypeData = {
   lastTimestamp: number
@@ -49,7 +50,7 @@ export type ValidationResult = {
   message?: string
 }
 
-export type AuthHandler = (msg: string) => Promise<string>
+export type AuthHandler = (msg: string) => Promise<ValidationMessagePayload>
 
 export type PeerConfig = {
   connectionConfig?: any

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,7 +88,7 @@ export type PeerConfig = {
 
 export type PeerEventsHandler = {
   statusHandler?: (status: PeerStatus) => void
-  onIslandChange?: (islandId: string) => any
+  onIslandChange?: (islandId: string | undefined) => any
   onPeerLeftIsland?: (peerId: string) => any
   onPeerJoinedIsland?: (peerId: string) => any
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import SimplePeer from 'simple-peer'
 import { Position3D } from './utils/Positions'
 import { SocketBuilder } from './peerjs-server-connector/socket'
 import { Packet } from './proto/peer_protobuf'
-import { ValidationMessagePayload } from 'peerjs-server-connector/peerjsserverconnection'
+import { ValidationMessagePayload } from './peerjs-server-connector/peerjsserverconnection'
 
 type PacketSubtypeData = {
   lastTimestamp: number

--- a/test/Peer.integration.spec.ts
+++ b/test/Peer.integration.spec.ts
@@ -817,9 +817,11 @@ describe('Peer Integration Test', function () {
   it('raises an specific error when the requested id is taken', async () => {
     let idTakenErrorReceived = false
     extraPeersConfig = {
-      statusHandler: (status) => {
-        if (status === 'id-taken') {
-          idTakenErrorReceived = true
+      eventsHandler: {
+        statusHandler: (status) => {
+          if (status === 'id-taken') {
+            idTakenErrorReceived = true
+          }
         }
       }
     }


### PR DESCRIPTION
Add peer events handler to allow the explorer to track the events of:
- IslandChange
- Peer entering or leaving the island
- Status change

Island change and status change events already existed and were moved into the events handler